### PR TITLE
Update test file to be pypy compatible (and add `requirements.txt`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+
+cffi==1.14.3
+clipboard==0.0.4
+greenlet==0.4.13
+numpy==1.19.4
+protobuf==3.14.0
+pyperclip==1.8.1
+readline==6.2.4.1
+six==1.15.0


### PR DESCRIPTION
* Swaps out the `pympler` memory grabber for `resource` which instead pulls total current resource usage. This is done because pympler's `asizeof` is not compatible with pypy.
* Adds in a `gc.collect()` call before the solution code. Along with the above change, this should ensure a solution's memory does not carry over -- assuming there are no memory leaks.
* Added a `requirements.txt` for the ease of just using `pip install -r requirements.txt` rather than fishing dependencies out while running it 😅

Here's what I've used to run this using pypy on MacOS.

```bash
# Install pypy3 and openblas (library)
brew install pypy3 openblas
# Update pypyp pip essentials.
pip_pypy3 install --upgrade pip setuptools wheel
# Compile numpy for pypy with the local openblas. without doing this,
# the pypy numpy installation will have runtime errors (at least on my setup)
OPENBLAS="$(brew --prefix openblas)" pip_pypy3 install numpy
# Install the other requirements.
pip_pypy3 install -r requirements.txt

# Vroom!
pypy3 tests/test_game.py
```