### PR TITLE
Add custom copy method for Atom and Molecule

### DIFF
--- a/schem/components.py
+++ b/schem/components.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import collections
-import copy
 import itertools
 import math
 from typing import List, Optional
@@ -424,7 +423,7 @@ class Input(Component):
         # Note that we tell the output pipe it's the next cycle, to 'move' its contents before outputting.
         # This prevents double-moving the molecule and allows for continuous flow in the rate = 1 case
         if (cycle - 1) % self.input_rate == 0 and self.out_pipe.get(0, cycle + 1) is None:
-            self.out_pipe.push(copy.deepcopy(self.molecules[0]), cycle + 1)
+            self.out_pipe.push(self.molecules[0].copy(), cycle + 1)
             self.num_inputs += 1
 
     def reset(self):
@@ -484,7 +483,7 @@ class RandomInput(Input):
         # -1 necessary since starting cycle is 1 not 0, while mod == 1 would break on rate = 1
         # Note that we tell the output pipe it's the next cycle, to 'move' its contents before outputting
         if (cycle - 1) % self.input_rate == 0 and self.out_pipe.get(0, cycle + 1) is None:
-            self.out_pipe.push(copy.deepcopy(self.molecules[self.get_next_molecule_idx()]), cycle + 1)
+            self.out_pipe.push(self.molecules[self.get_next_molecule_idx()].copy(), cycle + 1)
             self.num_inputs += 1
 
     def reset(self):
@@ -526,10 +525,10 @@ class ProgrammedInput(Input):
         # Note that we tell the output pipe it's the next cycle, to 'move' its contents before outputting
         if (cycle - 1) % self.input_rate == 0 and self.out_pipe.get(0, cycle + 1) is None:
             if self.starting_idx == len(self.starting_molecules):
-                self.out_pipe.push(copy.deepcopy(self.repeating_molecules[self.repeating_idx]), cycle + 1)
+                self.out_pipe.push(self.repeating_molecules[self.repeating_idx].copy(), cycle + 1)
                 self.repeating_idx = (self.repeating_idx + 1) % len(self.repeating_molecules)
             else:
-                self.out_pipe.push(copy.deepcopy(self.starting_molecules[self.starting_idx]), cycle + 1)
+                self.out_pipe.push(self.starting_molecules[self.starting_idx].copy(), cycle + 1)
                 self.starting_idx += 1
 
             self.num_inputs += 1

--- a/schem/molecule.py
+++ b/schem/molecule.py
@@ -27,6 +27,9 @@ class Atom:
         self.element = element
         self.bonds = bonds if bonds is not None else {}
 
+    def copy(self):
+        return Atom(self.element, self.bonds.copy())
+
     def __str__(self):
         return self.element.symbol
 
@@ -57,6 +60,9 @@ class Molecule:
     def __init__(self, name='', atom_map=None):
         self.name = name
         self.atom_map = atom_map if atom_map is not None else {}
+
+    def copy(self):
+        return Molecule(self.name, {pos: atom.copy() for pos, atom in self.atom_map.items()})
 
     @classmethod
     def from_json_string(cls, json_string):

--- a/schem/solution.py
+++ b/schem/solution.py
@@ -996,7 +996,7 @@ class Solution:
                         # molecules along to fill each other's positions
                         # Make sure to use right-indexing
                         del random_input.out_pipe._molecules[num_pipe_mols - 1 - remove_idx]  # slow but oh well
-                        new_molecule = copy.deepcopy(random_input.molecules[random_input.get_next_molecule_idx()])
+                        new_molecule = random_input.molecules[random_input.get_next_molecule_idx()].copy()
                         random_input.out_pipe._molecules.appendleft(new_molecule)
 
                         idx_offset += 1


### PR DESCRIPTION
`copy.deepcopy()` is slow, and copies a lot of stuff it doesn't need to. This change cuts test runtimes by ~15% on average.